### PR TITLE
Fix off-by-one error and add error reporting

### DIFF
--- a/src/ota_tool.cc
+++ b/src/ota_tool.cc
@@ -130,19 +130,24 @@ void launch_apply(char *partition) {
       jobs[job_count++].out = out;
       total_operations += part.operations_size();
 
+
       if (partition != NULL) {
         return;
       }
     }
   }
 }
+
+int ret_code = 0;
+
 void* run_apply(void *a) {
   section *queue = (section*)a;
 
   FILE *f = fopen(args.update_file, "rb");
 
-  while (queue->part != NULL) {
-    apply_section(&update, queue, f);
+  while (queue->part != NULL && !ret_code) {
+    if (apply_section(&update, queue, f))
+      ret_code = 1;
 
     queue++;
   }
@@ -241,7 +246,7 @@ INIT_FUNC(apply) {
     close(jobs[job].out);
   }
 
-  return 0;
+  return ret_code;
 }
 
 INIT_FUNC(main) {

--- a/src/ota_tool.cc
+++ b/src/ota_tool.cc
@@ -203,7 +203,7 @@ INIT_FUNC(apply) {
     int ops_in_part = update.manifest.partitions(jobs[job].part_number).operations_size();
     int ops_left = ops_in_part - used;
     if (ops_left <= ops_needed) {
-      thread_queue[section_i].end = ops_in_part - 1;
+      thread_queue[section_i].end = ops_in_part;
       job++;
       used = 0;
       ops_needed -= ops_left;

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -115,7 +115,8 @@ char* get_src(int in, unsigned int *size,
   return src;
 }
 
-void apply_section(payload *update, section *section, FILE *data_file) {
+int apply_section(payload *update, section *section, FILE *data_file) {
+  int ret = 1;
   const char* part_name = update->manifest.partitions(section->part->part_number).partition_name().data();
   while (section->start < section->end) {
     chromeos_update_engine::InstallOperation op = update->manifest.partitions(section->part->part_number).operations(section->start++);
@@ -180,7 +181,7 @@ void apply_section(payload *update, section *section, FILE *data_file) {
         break;
       default:
         log_err(part_name, "Unknown Operation Type");
-        return;
+        goto end;
     }
 
     write_out(section->part->out, &op, output);
@@ -188,6 +189,8 @@ void apply_section(payload *update, section *section, FILE *data_file) {
     if (output != src && output != data) {
       free(output);
     }
+
+    ret = 0;
 end:
     if (data != 0) {
       free(data);
@@ -196,6 +199,5 @@ end:
       free(src);
     }
   }
+  return ret;
 }
-
-

--- a/src/payload.h
+++ b/src/payload.h
@@ -71,7 +71,7 @@ char* output_buffer(const chromeos_update_engine::InstallOperation *op, unsigned
 char* get_src(int in, unsigned int *size,
   const chromeos_update_engine::InstallOperation *op);
 
-void apply_section(payload *update, section *section, FILE *data_file);
+int apply_section(payload *update, section *section, FILE *data_file);
 
  
 #endif /* ifndef _H_PAYLOAD */


### PR DESCRIPTION
Two changes included:

1. Fix an off-by-one error causing all partitions to miss the last operation, when applying changes, leading to corruption.
2. Add error reporting for 'apply' operation, thus making this tool script friendly.

Thank you for this amazing tool! I'm using it to validate Android OTA partial and full packages,