### PR TITLE
Make base image path optional

### DIFF
--- a/src/ota_tool.cc
+++ b/src/ota_tool.cc
@@ -81,8 +81,6 @@ parse_opt (int key, char *arg, struct argp_state *state)
     case ARGP_KEY_END:
       if (!arguments->update_file)
         argp_usage(state);
-      if (!arguments->input)
-        argp_usage(state);
       if (!arguments->output)
         argp_usage(state);
       break;
@@ -112,12 +110,15 @@ void launch_apply(char *partition) {
 
     if (partition == NULL || strcmp(partition_name, partition) == 0) {
 
-      int in = open_img_file(args.input, partition_name, O_RDONLY);
-      if (in < 0) {
-        if (partition != NULL) {
-          log_err(partition, "Could not open the source image for reading");
+      int in = -1;
+      if (args.input) {
+        in = open_img_file(args.input, partition_name, O_RDONLY);
+        if (in < 0) {
+          if (partition != NULL) {
+            log_err(partition, "Could not open the source image for reading");
+          }
+          continue;
         }
-        continue;
       }
       int out = open_img_file(args.output, partition_name, O_WRONLY | O_CREAT | O_TRUNC);
       if (out < 0) {

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -100,7 +100,7 @@ char* get_src(int in, unsigned int *size,
     *size += b2o(src_extent.num_blocks());
   }
 
-  if (*size == 0) {
+  if (*size == 0 || in < 0) {
     return (char*)0;
   }
 
@@ -130,6 +130,11 @@ void apply_section(payload *update, section *section, FILE *data_file) {
     uint64_t mem_limit = 1410065407;
     size_t next = 0;
     size_t out = 0;
+
+    if (src_size && !src) {
+      log_err(part_name, "Incremental OTA package, requiring a base image. Either none was given, or it is inaccessible.");
+      goto end;
+    }
 
     if (op.has_src_sha256_hash()) {
       sha256_bytes(src, src_size, hash);
@@ -197,5 +202,3 @@ end:
     }
   }
 }
-
-


### PR DESCRIPTION
Relax requirement for image path to support complete (non-partial) OTA packages without the need to provide a folder with base images (which are never used anyway).

Tested as following:
Complete OTA
./ota-tool apply -o channel_ota/payload channel_ota.zip

Incremental OTA with base path
./ota-tool apply -i base/payload -o channel_ota_from_base/payload channel_ota_from_base.zip

Incremental OTA w/o base path
./ota-tool apply -o channel_ota_from_base/payload channel_ota_from_base.zip
...
ERROR: system_ext: Incremental OTA package, requiring a base image. Either none was given, or it is inaccessible.
ERROR: system_ext: Incremental OTA package, requiring a base image. Either none was given, or it is inaccessible.
...
